### PR TITLE
Add storebox_sealed_always and storebox_sealed groups

### DIFF
--- a/feature_pottery.lua
+++ b/feature_pottery.lua
@@ -67,7 +67,8 @@ minetest.register_node(modname .. ":pottery_claypot", {
 		storebox = 1,
 		totable = 1,
 		scaling_time = 150,
-		ceramic = 2
+		ceramic = 2,
+		storebox_sealed = 1,
 	},
 	paramtype = "light",
 	sounds = nodecore.sounds("nc_optics_glassy"),
@@ -89,7 +90,8 @@ minetest.register_node(modname .. ":pottery_claypot_glazed", {
 		storebox = 1,
 		totable = 1,
 		scaling_time = 200,
-		ceramic = 3
+		ceramic = 3,
+		storebox_sealed = 1,
 	},
 	paramtype = "light",
 	sounds = nodecore.sounds("nc_optics_glassy"),

--- a/feature_waterpot.lua
+++ b/feature_waterpot.lua
@@ -60,6 +60,7 @@ minetest.register_node(modname .. ":pottery_waterpot_glazed", {
 		waterpot = 1,
 		scaling_time = 200,
 		stack_as_node = 1,
+		storebox_sealed_always = 1,
 	},
 	stack_max = 1,
 	paramtype = "light",


### PR DESCRIPTION
With the `storebox_sealed_always` group, ceramic waterpots are considered "atmospherically sealed", which is what prevents sponges (and potentially also corals, see wintersknight94/NodeCore-SeaLife#2) from dying simply by being put inside them.

In addition, this PR also adds the `storebox_sealed` groups to the other fired clay pots, which enables this functionality as long as the open side of the storebox (in claypots' case, the top) is sealed.